### PR TITLE
Fix amp-console to properly install inside /vendor/bin

### DIFF
--- a/amp-console
+++ b/amp-console
@@ -1,1 +1,0 @@
-amp-console.php

--- a/bin/amp-console
+++ b/bin/amp-console
@@ -18,7 +18,13 @@
 
 // amp-console.php
 error_reporting(E_ALL ^ E_NOTICE);
-require __DIR__.'/vendor/autoload.php';
+
+// Check if amp-console is installed as composer package.
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
 
 use Lullabot\AMP\AmpCommand;
 use Symfony\Component\Console\Application;

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/console": ">=2.7.0",
         "marc1706/fast-image-size": "1.*"
     },
+    "bin": ["bin/amp-console"],
     "autoload": {
         "classmap": ["src/Spec/validator-generated.php"],
         "psr-4": {"Lullabot\\AMP\\": "src"}


### PR DESCRIPTION
- Removes duplicate amp-console symlink
- moves amp-console to /bin/amp-console
- add `bin/amp-console` to composer so it can be exposed in `/vendor/bin` correctly.
  - This is importantly if not it'll be hard for people to be able to properly run `/vendor/bin/amp-console`
