### PR TITLE
Changed Twitter pass

### DIFF
--- a/src/Pass/TwitterTransformPass.php
+++ b/src/Pass/TwitterTransformPass.php
@@ -161,9 +161,9 @@ class TwitterTransformPass extends BasePass
         foreach ($links as $link) {
             $href = $link->attr('href');
             $matches = [];
-            if (preg_match('&(*UTF8)twitter.com/.*/status/([^/]+)&i', $href, $matches)) {
-                if (!empty($matches[1])) {
-                    $tweet_id = $matches[1];
+            if (preg_match('&(*UTF8)twitter.com/.*/status(es){0,1}/([^/]+)&i', $href, $matches)) {
+                if (!empty($matches[2])) {
+                    $tweet_id = $matches[2];
                     break;
                 }
             }


### PR DESCRIPTION
The Twitter pass wouldn't detect Twitter link with the format https://twitter.com/{user}/statuses/{id}. Note the "statuses" instead of "status". Now, I don't know where those links come from, but I do found them in one of my projects, so I made this quick fix.
