### PR TITLE
Add the ability to skip tests that require an internet connection

### DIFF
--- a/tests/AmpTest.php
+++ b/tests/AmpTest.php
@@ -23,12 +23,14 @@ use Lullabot\AMP\AMP;
  */
 class AmpTest extends PHPUnit_Framework_TestCase
 {
-    /** @var AMP|null */
+    /** @var AMP */
     protected $amp = null;
+    protected $skip_internet = false;
 
     public function setup()
     {
         $this->amp = new AMP();
+        $this->skip_internet = getenv('AMP_TEST_SKIP_INTERNET');
     }
 
     /**
@@ -45,6 +47,10 @@ class AmpTest extends PHPUnit_Framework_TestCase
         if ($expected_output === false) {
             // An out file does not exist, skip this test
             $this->markTestSkipped("$test_filename.out file does not exist. Skipping test.");
+        }
+
+        if (!empty($this->skip_internet) && !empty($options['requires_internet'])) {
+            $this->markTestSkipped("Skipping test as it requires internet and AMP_TEST_SKIP_INTERNET environment variable is set.");
         }
         $this->assertEquals($expected_output, $output);
     }

--- a/tests/test-data/fragment-html/facebook-non-iframe-fragment.html.options.json
+++ b/tests/test-data/fragment-html/facebook-non-iframe-fragment.html.options.json
@@ -1,0 +1,4 @@
+{
+    "_readme" : "requires_internet is just for information for the test runner and has no significance for the functioning of library",
+    "requires_internet": "true"
+}

--- a/tests/test-data/fragment-html/instagram-fragment.html.options.json
+++ b/tests/test-data/fragment-html/instagram-fragment.html.options.json
@@ -1,0 +1,4 @@
+{
+  "_readme" : "requires_internet is just for information for the test runner and has no significance for the functioning of library",
+  "requires_internet": "true"
+}

--- a/tests/test-data/fragment-html/sample-html-fragment.html.options.json
+++ b/tests/test-data/fragment-html/sample-html-fragment.html.options.json
@@ -1,0 +1,4 @@
+{
+  "_readme" : "requires_internet is just for information for the test runner and has no significance for the functioning of library",
+  "requires_internet": "true"
+}


### PR DESCRIPTION
Sometimes you want to run tests that don't require an internet connection. This PR adds that ability.

How to use
- Set environment variable AMP_TEST_SKIP_INTERNET=1 and then run `phpunit tests` and the tests
  that require an internet connection will be skipped
  
  As a shortcut from the command line
  
  ``` bash
  $ AMP_TEST_SKIP_INTERNET=1 vendor/bin/phpunit tests
  ```
- `unset AMP_TEST_SKIP_INTERNET` (or set it to 0) if you _don't_ want internet tests to be skipped
