### PR TITLE
Return empty array if there are no query params

### DIFF
--- a/src/Pass/BasePass.php
+++ b/src/Pass/BasePass.php
@@ -249,7 +249,7 @@ abstract class BasePass
 
         $query = ParseUrl::parse_url($href, PHP_URL_QUERY);
         if ($query === null) {
-            return false;
+            return [];
         }
 
         $arr = [];


### PR DESCRIPTION
See #132
