### PR TITLE
Convert 1x1 <img> to <amp-pixel>

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -90,7 +90,8 @@ class ImgTagTransformPass extends BasePass
         return $this->transformations;
     }
 
-    protected function convertAmpPixel($el, $lineno, $context_string) {
+    protected function convertAmpPixel($el, $lineno, $context_string)
+    {
         $dom_el = $el->get(0);
         $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
         $new_dom_el->setAttribute('src', $el->attr('src'));
@@ -99,7 +100,8 @@ class ImgTagTransformPass extends BasePass
         return $new_dom_el;
     }
 
-    protected function convertAmpImg($el, $lineno, $context_string) {
+    protected function convertAmpImg($el, $lineno, $context_string)
+    {
         $dom_el = $el->get(0);
         $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
         $new_el = $el->prev();

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -78,11 +78,12 @@ class ImgTagTransformPass extends BasePass
                 continue;
             }
             if ($this->isPixel($el)) {
-                $this->convertAmpPixel($el, $lineno, $context_string);
+                $new_dom_el = $this->convertAmpPixel($el, $lineno, $context_string);
             }
             else {
-                $this->convertAmpImg($el, $lineno, $context_string);
+                $new_dom_el = $this->convertAmpImg($el, $lineno, $context_string);
             }
+            $this->context->addLineAssociation($new_dom_el, $lineno);
             $el->remove(); // remove the old img tag
         }
 
@@ -94,8 +95,8 @@ class ImgTagTransformPass extends BasePass
         $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
         $new_dom_el->setAttribute('src', $el->attr('src'));
         $dom_el->parentNode->insertBefore($new_dom_el, $dom_el);
-        $this->context->addLineAssociation($new_dom_el, $lineno);
         $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
+        return $new_dom_el;
     }
 
     protected function convertAmpImg($el, $lineno, $context_string) {
@@ -103,8 +104,8 @@ class ImgTagTransformPass extends BasePass
         $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
         $new_el = $el->prev();
         $this->setLayoutIfNoLayout($new_el, 'responsive');
-        $this->context->addLineAssociation($new_dom_el, $lineno);
         $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
+        return $new_dom_el;
     }
 
     /**

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -72,22 +72,31 @@ class ImgTagTransformPass extends BasePass
                 continue;
             }
             $context_string = $this->getContextString($dom_el);
-            $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
-            $new_el = $el->prev();
+            if ($el->attr('width') === '1' && $el->attr('height') === '1') {
+                // Convert 1x1 images to amp-pixel tracking tags
+                $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-pixel');
+                $this->context->addLineAssociation($new_dom_el, $lineno);
+                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
+            }
+            else {
+                $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
+                $new_el = $el->prev();
 
-            $success = $this->setResponsiveImgHeightAndWidth($new_el);
-            // We were not able to get the image dimensions, abort conversion.
-            if (!$success) {
-                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
-                // Abort the conversion and remove the new img tag
-                $new_el->remove();
-                continue;
+                $success = $this->setResponsiveImgHeightAndWidth($new_el);
+                // We were not able to get the image dimensions, abort conversion.
+                if (!$success) {
+                    $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
+                    // Abort the conversion and remove the new img tag
+                    $new_el->remove();
+                    continue;
+                }
+
+                $this->setLayoutIfNoLayout($new_el, 'responsive');
+                $this->context->addLineAssociation($new_dom_el, $lineno);
+                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
             }
 
             $el->remove(); // remove the old img tag
-            $this->setLayoutIfNoLayout($new_el, 'responsive');
-            $this->context->addLineAssociation($new_dom_el, $lineno);
-            $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
         }
 
         return $this->transformations;

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -72,8 +72,8 @@ class ImgTagTransformPass extends BasePass
             }
             $lineno = $this->getLineNo($dom_el);
             $context_string = $this->getContextString($dom_el);
-            $hasWidthAndHeight = $this->setResponsiveImgHeightAndWidth($el);
-            if (!$hasWidthAndHeight) {
+            $has_height_and_width = $this->setResponsiveImgHeightAndWidth($el);
+            if (!$has_height_and_width) {
                 $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
                 continue;
             }

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -90,6 +90,14 @@ class ImgTagTransformPass extends BasePass
         return $this->transformations;
     }
 
+    /**
+     * Given an image element returns an amp-pixel element with the same source
+     *
+     * @param DOMQuery $el
+     * @param int $lineno
+     * @param string $context_string
+     * @return DOMElement
+     */
     protected function convertAmpPixel($el, $lineno, $context_string)
     {
         $dom_el = $el->get(0);
@@ -100,6 +108,14 @@ class ImgTagTransformPass extends BasePass
         return $new_dom_el;
     }
 
+    /**
+     * Given an image element returns an amp-img element with the same attributes and children
+     *
+     * @param DOMQuery $el
+     * @param int $lineno
+     * @param string $context_string
+     * @return DOMElement
+     */
     protected function convertAmpImg($el, $lineno, $context_string)
     {
         $dom_el = $el->get(0);

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -145,12 +145,14 @@ class ImgTagTransformPass extends BasePass
 
     /**
      * Detects if the img is a 1x1 pixel. In that case we convert to <amp-pixel> instead of <amp-img>
-     * @param \DOMElement $el
+     * @param DOMQuery $el
      * @return bool
      */
     protected function isPixel(DOMQuery $el)
     {
-        $this->setResponsiveImgHeightAndWidth($el);
+        if (!$this->setResponsiveImgHeightAndWidth($el)) {
+            return false;
+        }
         return $el->attr('width') === '1' && $el->attr('height') === '1';
     }
 

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -78,14 +78,10 @@ class ImgTagTransformPass extends BasePass
                 continue;
             }
             if ($this->isPixel($el)) {
-                $new_dom_el = $this->convertAmpPixel($el);
-                $this->context->addLineAssociation($new_dom_el, $lineno);
-                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
+                $this->convertAmpPixel($el, $lineno, $context_string);
             }
             else {
-                $new_dom_el = $this->convertAmpImg($el);
-                $this->context->addLineAssociation($new_dom_el, $lineno);
-                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
+                $this->convertAmpImg($el, $lineno, $context_string);
             }
             $el->remove(); // remove the old img tag
         }
@@ -93,20 +89,22 @@ class ImgTagTransformPass extends BasePass
         return $this->transformations;
     }
 
-    protected function convertAmpPixel($el) {
+    protected function convertAmpPixel($el, $lineno, $context_string) {
         $dom_el = $el->get(0);
         $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
         $new_dom_el->setAttribute('src', $el->attr('src'));
         $dom_el->parentNode->insertBefore($new_dom_el, $dom_el);
-        return $new_dom_el;
+        $this->context->addLineAssociation($new_dom_el, $lineno);
+        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
     }
 
-    protected function convertAmpImg($el) {
+    protected function convertAmpImg($el, $lineno, $context_string) {
         $dom_el = $el->get(0);
         $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
         $new_el = $el->prev();
         $this->setLayoutIfNoLayout($new_el, 'responsive');
-        return $new_dom_el;
+        $this->context->addLineAssociation($new_dom_el, $lineno);
+        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
     }
 
     /**

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -95,7 +95,7 @@ class ImgTagTransformPass extends BasePass
         $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
         $new_dom_el->setAttribute('src', $el->attr('src'));
         $dom_el->parentNode->insertBefore($new_dom_el, $dom_el);
-        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
+        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
         return $new_dom_el;
     }
 
@@ -104,7 +104,7 @@ class ImgTagTransformPass extends BasePass
         $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
         $new_el = $el->prev();
         $this->setLayoutIfNoLayout($new_el, 'responsive');
-        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
+        $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
         return $new_dom_el;
     }
 
@@ -154,9 +154,6 @@ class ImgTagTransformPass extends BasePass
      */
     protected function isPixel(DOMQuery $el)
     {
-        if (!$this->setResponsiveImgHeightAndWidth($el)) {
-            return false;
-        }
         return $el->attr('width') === '1' && $el->attr('height') === '1';
     }
 

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -72,9 +72,11 @@ class ImgTagTransformPass extends BasePass
                 continue;
             }
             $context_string = $this->getContextString($dom_el);
-            if ($el->attr('width') === '1' && $el->attr('height') === '1') {
+            if ($this->isPixel($el)) {
                 // Convert 1x1 images to amp-pixel tracking tags
-                $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-pixel');
+                $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
+                $new_dom_el->setAttribute('src', $el->attr('src'));
+                $dom_el->parentNode->insertBefore($new_dom_el, $dom_el);
                 $this->context->addLineAssociation($new_dom_el, $lineno);
                 $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_PIXEL_CONVERTED, $lineno, $context_string));
             }
@@ -139,6 +141,17 @@ class ImgTagTransformPass extends BasePass
         }
 
         return false;
+    }
+
+    /**
+     * Detects if the img is a 1x1 pixel. In that case we convert to <amp-pixel> instead of <amp-img>
+     * @param \DOMElement $el
+     * @return bool
+     */
+    protected function isPixel(DOMQuery $el)
+    {
+        $this->setResponsiveImgHeightAndWidth($el);
+        return $el->attr('width') === '1' && $el->attr('height') === '1';
     }
 
     /**

--- a/src/Utility/ActionTakenType.php
+++ b/src/Utility/ActionTakenType.php
@@ -24,6 +24,7 @@ class ActionTakenType
     const PROPERTY_REMOVED = 'property value pair was removed from attribute due to validation issues.';
     const PROPERTY_REMOVED_ATTRIBUTE_REMOVED = 'property value pair was removed from attribute due to validation issues. The resulting attribute was empty and was also removed.';
     const IMG_CONVERTED = 'tag was converted to the amp-img tag.';
+    const IMG_PIXEL_CONVERTED = 'tag was converted to the amp-pixel tag.';
     const IMG_COULD_NOT_BE_CONVERTED = 'tag could NOT be converted to the amp-img tag as the image is not accessible.';
     const INSTAGRAM_CONVERTED = 'instagram embed code was converted to the amp-instagram tag.';
     const PINTEREST_CONVERTED = 'pinterest embed code was converted to the amp-pinterest tag.';

--- a/tests/test-data/fragment-html/img-test-fragment.html
+++ b/tests/test-data/fragment-html/img-test-fragment.html
@@ -20,3 +20,6 @@
 
 <!-- since units are inconsistent, overwrite with height+width from original image -->
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625rem" height="480"></amp-img>
+
+<!-- should transform to amp-pixel -->
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1">

--- a/tests/test-data/fragment-html/img-test-fragment.html
+++ b/tests/test-data/fragment-html/img-test-fragment.html
@@ -22,4 +22,4 @@
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625rem" height="480"></amp-img>
 
 <!-- should transform to amp-pixel -->
-<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1">
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/ce/Transparent.gif">

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -22,7 +22,7 @@
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
 <!-- should transform to amp-pixel -->
-<amp-pixel src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1"></amp-pixel>
+<amp-pixel src="https://upload.wikimedia.org/wikipedia/commons/c/ce/Transparent.gif"></amp-pixel>
 
 ORIGINAL HTML
 ---------------
@@ -50,7 +50,7 @@ Line 21: <!-- since units are inconsistent, overwrite with height+width from ori
 Line 22: <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625rem" height="480"></amp-img>
 Line 23: 
 Line 24: <!-- should transform to amp-pixel -->
-Line 25: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1">
+Line 25: <img src="https://upload.wikimedia.org/wikipedia/commons/c/ce/Transparent.gif">
 
 
 Transformations made from HTML tags to AMP custom tags
@@ -65,7 +65,7 @@ Transformations made from HTML tags to AMP custom tags
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg"> at line 10
  ACTION TAKEN: img tag could NOT be converted to the amp-img tag as the image is not accessible.
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1"> at line 25
+<img src="https://upload.wikimedia.org/wikipedia/commons/c/ce/Transparent.gif"> at line 25
  ACTION TAKEN: img tag was converted to the amp-pixel tag.
 
 

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -21,6 +21,9 @@
 <!-- since units are inconsistent, overwrite with height+width from original image -->
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
+<!-- should transform to amp-pixel -->
+<amp-pixel src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1"></amp-pixel>
+
 ORIGINAL HTML
 ---------------
 Line  1: <!-- Note: this image is in the public domain. https://commons.wikimedia.org/wiki/File:"Birdcatcher"_with_jockey_up.jpg -->
@@ -45,6 +48,9 @@ Line 19: <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedi
 Line 20: 
 Line 21: <!-- since units are inconsistent, overwrite with height+width from original image -->
 Line 22: <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625rem" height="480"></amp-img>
+Line 23: 
+Line 24: <!-- should transform to amp-pixel -->
+Line 25: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1">
 
 
 Transformations made from HTML tags to AMP custom tags
@@ -58,6 +64,9 @@ Transformations made from HTML tags to AMP custom tags
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg"> at line 10
  ACTION TAKEN: img tag could NOT be converted to the amp-img tag as the image is not accessible.
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="1" height="1"> at line 25
+ ACTION TAKEN: img tag was converted to the amp-pixel tag.
 
 
 AMP-HTML Validation Issues and Fixes


### PR DESCRIPTION
This PR converts 1x1 images to [amp-pixel](https://www.ampproject.org/docs/reference/amp-pixel.html) tags (instead of amp-img).
