### PR TITLE
Add img_max_fixed_layout_width option

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -121,9 +121,22 @@ class ImgTagTransformPass extends BasePass
         $dom_el = $el->get(0);
         $new_dom_el = $this->cloneAndRenameDomElement($dom_el, 'amp-img');
         $new_el = $el->prev();
-        $this->setLayoutIfNoLayout($new_el, 'responsive');
+        $this->setLayoutIfNoLayout($new_el, $this->getLayout($el));
         $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_CONVERTED, $lineno, $context_string));
         return $new_dom_el;
+    }
+
+    /**
+     * Given an image DOMQuery
+     * Returns whether the image should have 'fixed' or 'responsive' layout
+     *
+     * @param DOMQuery $el
+     * @return string
+     */
+    protected function getLayout($el) {
+        return (isset($this->options['img_max_fixed_layout_width'])
+            && $this->options['img_max_fixed_layout_width'] >= $el->attr('width'))
+            ? 'fixed' : 'responsive';
     }
 
     /**

--- a/tests/test-data/fragment-html/img-test-fragment.html
+++ b/tests/test-data/fragment-html/img-test-fragment.html
@@ -3,7 +3,7 @@
 <!-- should transform to amp-img -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg">
 
-<!-- should transform to amp-img with responsive layout, preserving the width and height -->
+<!-- should transform to amp-img with fixed layout, preserving the width and height -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 
 <!-- nonexistent image, should refuse to convert to amp-img -->

--- a/tests/test-data/fragment-html/img-test-fragment.html.options.json
+++ b/tests/test-data/fragment-html/img-test-fragment.html.options.json
@@ -1,0 +1,3 @@
+{
+  "img_max_fixed_layout_width" : 200
+}

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -3,8 +3,8 @@
 <!-- should transform to amp-img -->
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480" layout="responsive"></amp-img>
 
-<!-- should transform to amp-img with responsive layout, preserving the width and height -->
-<amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="responsive"></amp-img>
+<!-- should transform to amp-img with fixed layout, preserving the width and height -->
+<amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="fixed"></amp-img>
 
 <!-- nonexistent image, should refuse to convert to amp-img -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
@@ -31,7 +31,7 @@ Line  2:
 Line  3: <!-- should transform to amp-img -->
 Line  4: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg">
 Line  5: 
-Line  6: <!-- should transform to amp-img with responsive layout, preserving the width and height -->
+Line  6: <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 Line  7: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 Line  8: 
 Line  9: <!-- nonexistent image, should refuse to convert to amp-img -->


### PR DESCRIPTION
When the `img_max_fixed_layout_width_option` is set, any images that have a width less than or equal to the option value will get a `layout='fixed'` instead of `layout='responsive'` attribute.

This fixes issue #143 
