### PR TITLE
Support Facebook posts with photo url schemas

### DIFF
--- a/src/Pass/BaseFacebookPass.php
+++ b/src/Pass/BaseFacebookPass.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright 2016 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Lullabot\AMP\Pass;
+
+abstract class BaseFacebookPass extends BasePass
+{
+    /**
+     * Checks whether the given url is a valid facebook post url
+     *
+     * @param string $url
+     * @return bool
+     */
+    protected function isValidPostUrl($url)
+    {
+        return
+            // e.g. https://www.facebook.com/20531316728/posts/10154009990506729/
+            preg_match('&(*UTF8)facebook\.com/.*/posts/\d+/?&i', $url)
+            // e.g. https://www.facebook.com/photos/{photo-id}
+            // or https://www.facebook.com/SanAntonioVAMC/photos/a.411451129506.185409.351086129506/10154231221264507/?type=3&amp;theater
+            || preg_match('&(*UTF8)facebook\.com/.*photos.*&i', $url)
+            // e.g. https://www.facebook.com/photo.php?fbid={photo-id}
+            // or https://www.facebook.com/photo.php?v=10153655829445601
+            || preg_match('&(*UTF8)facebook\.com/photo\.php.*&i', $url);
+    }
+
+    protected function isValidVideoUrl($url)
+    {
+        return
+            // e.g https://www.facebook.com/facebook/videos/10153231379946729/
+            preg_match('&(*UTF8)facebook\.com/.*/videos/\d+/?&i', $url)
+            // e.g https://www.facebook.com/video.php?v=10153231379946729
+            || preg_match('&(*UTF8)facebook\.com/video\.php.*&i', $url);
+    }
+}

--- a/src/Pass/FacebookNonIframeTransformPass.php
+++ b/src/Pass/FacebookNonIframeTransformPass.php
@@ -38,7 +38,7 @@ use Lullabot\AMP\Utility\ActionTakenType;
  * @see https://github.com/ampproject/amphtml/blob/master/extensions/amp-facebook/amp-facebook.md
  * @see https://github.com/ampproject/amphtml/blob/master/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
  */
-class FacebookNonIframeTransformPass extends BasePass
+class FacebookNonIframeTransformPass extends BaseFacebookPass
 {
     const DEFAULT_WIDTH = 500;
     const DEFAULT_HEIGHT = 281;
@@ -109,8 +109,7 @@ class FacebookNonIframeTransformPass extends BasePass
         }
 
         $card = true;
-        // e.g https://www.facebook.com/facebook/videos/10153231379946729/
-        if (preg_match('&(*UTF8)facebook\.com/.*/videos/\d+/?&i', $src)) {
+        if ($this->isValidVideoUrl($src)) {
             // A facebook video can be embedded as a post. Doing that enables the video "card" to display
             if ($el->attr('data-show-text') !== "false") {
                 $embed_as = 'post';
@@ -118,8 +117,8 @@ class FacebookNonIframeTransformPass extends BasePass
             } else {
                 $embed_as = 'video';
             }
-        } // e.g. https://www.facebook.com/20531316728/posts/10154009990506729/
-        else if (preg_match('&(*UTF8)facebook\.com/.*/posts/\d+/?&i', $src)) {
+        }
+        elseif ($this->isValidPostUrl($src)) {
             $embed_as = 'post';
         } else {
             return false;

--- a/src/Pass/IframeFacebookTagTransformPass.php
+++ b/src/Pass/IframeFacebookTagTransformPass.php
@@ -54,7 +54,7 @@ use Lullabot\AMP\Utility\ActionTakenType;
  * @see https://github.com/ampproject/amphtml/blob/master/extensions/amp-facebook/amp-facebook.md
  * @see https://github.com/ampproject/amphtml/blob/master/extensions/amp-facebook/0.1/validator-amp-facebook.protoascii
  */
-class IframeFacebookTagTransformPass extends BasePass
+class IframeFacebookTagTransformPass extends BaseFacebookPass
 {
     const DEFAULT_ASPECT_RATIO = 1.7778;
     const DEFAULT_WIDTH = 500;
@@ -108,16 +108,15 @@ class IframeFacebookTagTransformPass extends BasePass
             return false;
         }
 
-        // e.g https://www.facebook.com/facebook/videos/10153231379946729/
-        if (preg_match('&(*UTF8)facebook\.com/facebook/videos/\d+/?&i', $query_arr['href'])) {
+        if ($this->isValidVideoUrl($query_arr['href'])) {
             // A facebook video can be embedded as a post. Doing that enables the video "card" to display
             if (isset($query_arr['show_text']) && $query_arr['show_text'] !== "false") {
                 $embed_as = 'post';
             } else {
                 $embed_as = 'video';
             }
-        } // e.g. https://www.facebook.com/20531316728/posts/10154009990506729/
-        else if (preg_match('&(*UTF8)facebook\.com/.*/posts/\d+/?&i', $query_arr['href'])) {
+        }
+        elseif ($this->isValidPostUrl($query_arr['href'])) {
             $embed_as = 'post';
         } else {
             return false;

--- a/tests/test-data/fragment-html/facebook-iframe-fragment.html
+++ b/tests/test-data/fragment-html/facebook-iframe-fragment.html
@@ -13,3 +13,7 @@
         width="500" height="290" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
         allowTransparency="true"></iframe>
 
+<!-- post -->
+<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fphoto.php%3Ffbid%3D986393557241%26set%3Da.941146602501.2418915.4%26type%3D3&width=500&show_text=true&appId=1355737204455009&height=439"
+        width="500" height="439" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
+        allowTransparency="true"></iframe>

--- a/tests/test-data/fragment-html/facebook-iframe-fragment.html.out
+++ b/tests/test-data/fragment-html/facebook-iframe-fragment.html.out
@@ -7,6 +7,8 @@
 <!-- post -->
 <amp-facebook layout="responsive" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/" data-embed-as="post" height="290" width="500"></amp-facebook>
 
+<!-- post -->
+<amp-facebook layout="responsive" data-href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3" data-embed-as="post" height="439" width="500"></amp-facebook>
 
 
 ORIGINAL HTML
@@ -26,7 +28,11 @@ Line 12: <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F
 Line 13:         width="500" height="290" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
 Line 14:         allowTransparency="true"></iframe>
 Line 15: 
-Line 16: 
+Line 16: <!-- post -->
+Line 17: <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fphoto.php%3Ffbid%3D986393557241%26set%3Da.941146602501.2418915.4%26type%3D3&width=500&show_text=true&appId=1355737204455009&height=439"
+Line 18:         width="500" height="439" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
+Line 19:         allowTransparency="true"></iframe>
+Line 20: 
 
 
 Transformations made from HTML tags to AMP custom tags
@@ -39,6 +45,9 @@ Transformations made from HTML tags to AMP custom tags
  ACTION TAKEN: iframe facebook embed code was converted to the amp-facebook tag.
 
 <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2F20531316728%2Fposts%2F10154009990506729%2F&width=500&show_text=false&height=290&appId" width="500" height="... at line 14
+ ACTION TAKEN: iframe facebook embed code was converted to the amp-facebook tag.
+
+<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fphoto.php%3Ffbid%3D986393557241%26set%3Da.941146602501.2418915.4%26type%3D3&width=500&show_text=true&appId=... at line 19
  ACTION TAKEN: iframe facebook embed code was converted to the amp-facebook tag.
 
 

--- a/tests/test-data/fragment-html/facebook-non-iframe-fragment.html
+++ b/tests/test-data/fragment-html/facebook-non-iframe-fragment.html
@@ -25,9 +25,27 @@
     </blockquote>
 </div>
 
+<div class="fb-video" data-href="https://www.facebook.com/video.php?v=10153231379946729" data-width="500"
+     data-show-text="true">
+    <blockquote cite="https://www.facebook.com/video.php?v=10153231379946729" class="fb-xfbml-parse-ignore"><a
+            href="https://www.facebook.com/video.php?v=10153231379946729">How to Share With Just Friends</a>
+        <p>How to share with just friends.</p>Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on
+        Friday, 5 December 2014
+    </blockquote>
+</div>
+
 <div class="fb-video" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-width="500" data-show-text="false">
     <blockquote cite="https://www.facebook.com/zuck/videos/10103066366848051/" class="fb-xfbml-parse-ignore">
     <a href="https://www.facebook.com/zuck/videos/10103066366848051/">Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</a>
     <p>Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on Monday, August 29, 2016
     </blockquote>
+</div>
+
+<div class="fb-post"
+     data-href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3"
+     data-width="500" data-show-text="true">
+    <blockquote cite="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3"
+                class="fb-xfbml-parse-ignore">Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on&nbsp;<a
+            href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3">Wednesday,
+        September 14, 2011</a></blockquote>
 </div>

--- a/tests/test-data/fragment-html/facebook-non-iframe-fragment.html.out
+++ b/tests/test-data/fragment-html/facebook-non-iframe-fragment.html.out
@@ -5,7 +5,11 @@
 
 <amp-facebook layout="responsive" data-href="https://www.facebook.com/facebook/videos/10153231379946729/" data-embed-as="post" height="366" width="500"></amp-facebook>
 
+<amp-facebook layout="responsive" data-href="https://www.facebook.com/video.php?v=10153231379946729" data-embed-as="post" height="366" width="500"></amp-facebook>
+
 <amp-facebook layout="responsive" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-embed-as="video" height="366" width="500"></amp-facebook>
+
+<amp-facebook layout="responsive" data-href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3" data-embed-as="post" height="366" width="500"></amp-facebook>
 
 ORIGINAL HTML
 ---------------
@@ -36,12 +40,30 @@ Line 24:         Friday, 5 December 2014
 Line 25:     </blockquote>
 Line 26: </div>
 Line 27: 
-Line 28: <div class="fb-video" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-width="500" data-show-text="false">
-Line 29:     <blockquote cite="https://www.facebook.com/zuck/videos/10103066366848051/" class="fb-xfbml-parse-ignore">
-Line 30:     <a href="https://www.facebook.com/zuck/videos/10103066366848051/">Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</a>
-Line 31:     <p>Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on Monday, August 29, 2016
-Line 32:     </blockquote>
-Line 33: </div>
+Line 28: <div class="fb-video" data-href="https://www.facebook.com/video.php?v=10153231379946729" data-width="500"
+Line 29:      data-show-text="true">
+Line 30:     <blockquote cite="https://www.facebook.com/video.php?v=10153231379946729" class="fb-xfbml-parse-ignore"><a
+Line 31:             href="https://www.facebook.com/video.php?v=10153231379946729">How to Share With Just Friends</a>
+Line 32:         <p>How to share with just friends.</p>Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on
+Line 33:         Friday, 5 December 2014
+Line 34:     </blockquote>
+Line 35: </div>
+Line 36: 
+Line 37: <div class="fb-video" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-width="500" data-show-text="false">
+Line 38:     <blockquote cite="https://www.facebook.com/zuck/videos/10103066366848051/" class="fb-xfbml-parse-ignore">
+Line 39:     <a href="https://www.facebook.com/zuck/videos/10103066366848051/">Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</a>
+Line 40:     <p>Live from our Townhall Q&amp;A in Rome. Comment to ask a question!</p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on Monday, August 29, 2016
+Line 41:     </blockquote>
+Line 42: </div>
+Line 43: 
+Line 44: <div class="fb-post"
+Line 45:      data-href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3"
+Line 46:      data-width="500" data-show-text="true">
+Line 47:     <blockquote cite="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3"
+Line 48:                 class="fb-xfbml-parse-ignore">Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on&nbsp;<a
+Line 49:             href="https://www.facebook.com/photo.php?fbid=986393557241&amp;set=a.941146602501.2418915.4&amp;type=3">Wednesday,
+Line 50:         September 14, 2011</a></blockquote>
+Line 51: </div>
 
 
 Transformations made from HTML tags to AMP custom tags
@@ -56,8 +78,14 @@ Transformations made from HTML tags to AMP custom tags
 <div class="fb-video" data-href="https://www.facebook.com/facebook/videos/10153231379946729/" data-width="500" data-show-text="true"> at line 20
  ACTION TAKEN: div.fb-video facebook javascript sdk embed code was converted to the amp-facebook tag.
 
-<div class="fb-video" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-width="500" data-show-text="false"> at line 28
+<div class="fb-video" data-href="https://www.facebook.com/video.php?v=10153231379946729" data-width="500" data-show-text="true"> at line 29
  ACTION TAKEN: div.fb-video facebook javascript sdk embed code was converted to the amp-facebook tag.
+
+<div class="fb-video" data-href="https://www.facebook.com/zuck/videos/10103066366848051/" data-width="500" data-show-text="false"> at line 37
+ ACTION TAKEN: div.fb-video facebook javascript sdk embed code was converted to the amp-facebook tag.
+
+<div class="fb-post" data-href="https://www.facebook.com/photo.php?fbid=986393557241&set=a.941146602501.2418915.4&type=3" data-width="500" data-show-text="true"> at line 46
+ ACTION TAKEN: div.fb-post facebook javascript sdk embed code was converted to the amp-facebook tag.
 
 
 AMP-HTML Validation Issues and Fixes


### PR DESCRIPTION
Adds support for converting embedded facebook posts that use a photo url schema:

```
https://www.facebook.com/photo.php?fbid={photo-id}
https://www.facebook.com/photos/{photo-id}
```

https://developers.facebook.com/docs/plugins/oembed-endpoints
