### PR TITLE
Bug fix: height check on setResponsiveImgHeightAndWidth

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -217,7 +217,7 @@ class ImgTagTransformPass extends BasePass
         $wcss = new CssLengthAndUnit($el->attr('width'), false);
         $hcss = new CssLengthAndUnit($el->attr('height'), false);
 
-        if ($wcss->is_set && $wcss->is_valid && $wcss->is_set && $wcss->is_valid && $wcss->unit == $hcss->unit) {
+        if ($wcss->is_set && $wcss->is_valid && $hcss->is_set && $hcss->is_valid && $wcss->unit == $hcss->unit) {
             return true;
         }
 

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -13,10 +13,10 @@
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" layout="responsive" width="625" height="480"></amp-img>
 
 <!-- since only width exists, overwrite with height and width from original image -->
-<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="500"></amp-img>
+<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
 <!-- since height is illegal, overwrite with height and width from original image -->
-<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625"></amp-img>
+<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
 <!-- since units are inconsistent, overwrite with height+width from original image -->
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>

--- a/tests/test-data/full-html/mandatory_dimensions.html.out
+++ b/tests/test-data/full-html/mandatory_dimensions.html.out
@@ -343,7 +343,6 @@ FAIL
 <amp-img src="img" layout="responsive" width="42"> on line 117
 - The mandatory attribute 'height' is missing in tag 'amp-img'.
    [code: MANDATORY_ATTR_MISSING  category: AMP_LAYOUT_PROBLEM see: https://www.ampproject.org/docs/reference/amp-img.html]
-   ACTION TAKEN: amp-img tried to fix problems with amp-img by trying to fetch height, width from image directly and/or setting layout to responsive
 
 <amp-img src="img" layout="fixed" height="42"> on line 118
 - The mandatory attribute 'width' is missing in tag 'amp-img'.


### PR DESCRIPTION
This PR fixes the height check on setResponsiveImgHeightAndWidth. Previously it was checking the width twice instead of the height and the width, so if an image only included the width attribute i.e.

`<img src="myimage.jpg" width="400" />`

Then an amp-img tag w/o a height attribute would be rendered
