### PR TITLE
Fix for the Youtube code getter

### DIFF
--- a/src/Pass/IframeYouTubeTagTransformPass.php
+++ b/src/Pass/IframeYouTubeTagTransformPass.php
@@ -122,7 +122,7 @@ class IframeYouTubeTagTransformPass extends BasePass
 
         // @todo there seem to be a lot of ways to embed a youtube video. We probably need to capture all patterns here
         // The next one is the embed code that youtube gives you
-        if (preg_match('&(*UTF8)/embed/([^/?]+)&i', $href, $matches)) {
+        if (preg_match('&(*UTF8)/embed/([^/?\&]+)&i', $href, $matches)) {
             if (!empty($matches[1])) {
                 $youtube_code = $matches[1];
                 return $youtube_code;

--- a/src/Pass/IframeYouTubeTagTransformPass.php
+++ b/src/Pass/IframeYouTubeTagTransformPass.php
@@ -129,7 +129,7 @@ class IframeYouTubeTagTransformPass extends BasePass
             }
         }
 
-        if (preg_match('&(*UTF8)youtu\.be/([^/?]+)&i', $href, $matches)) {
+        if (preg_match('&(*UTF8)youtu\.be/([^/?\&]+)&i', $href, $matches)) {
             if (!empty($matches[1])) {
                 $youtube_code = $matches[1];
                 return $youtube_code;

--- a/tests/test-data/fragment-html/youtube-02-fragment.html
+++ b/tests/test-data/fragment-html/youtube-02-fragment.html
@@ -1,0 +1,4 @@
+<iframe data-priority="high" width="560" height="315"
+        src="https://www.youtube.com/embed/MnR9AVs6Q_c&rel=0"
+        frameborder="0" allowfullscreen>
+</iframe>

--- a/tests/test-data/fragment-html/youtube-02-fragment.html.out
+++ b/tests/test-data/fragment-html/youtube-02-fragment.html.out
@@ -1,0 +1,25 @@
+<amp-youtube data-videoid="MnR9AVs6Q_c" layout="responsive" data-priority="high" height="315" width="560"></amp-youtube>
+
+ORIGINAL HTML
+---------------
+Line 1: <iframe data-priority="high" width="560" height="315"
+Line 2:         src="https://www.youtube.com/embed/MnR9AVs6Q_c&rel=0"
+Line 3:         frameborder="0" allowfullscreen>
+Line 4: </iframe>
+
+
+Transformations made from HTML tags to AMP custom tags
+-------------------------------------------------------
+
+<iframe data-priority="high" width="560" height="315" src="https://www.youtube.com/embed/MnR9AVs6Q_c&rel=0" frameborder allowfullscreen> at line 3
+ ACTION TAKEN: iframe tag was converted to the amp-youtube tag.
+
+
+AMP-HTML Validation Issues and Fixes
+-------------------------------------
+PASS
+
+COMPONENT NAMES WITH JS PATH
+------------------------------
+'amp-youtube', include path 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js'
+


### PR DESCRIPTION
Before adding the fix:

```
PHPUnit 4.8.31 by Sebastian Bergmann and contributors.

................E.......................................

Time: 2.67 seconds, Memory: 18.00MB

There was 1 error:

1) AmpTest::testFiles with data set "tests/test-data/fragment-html/youtube-02-fragment.html" ('tests/test-data/fragment-html...t.html', false)
QueryPath\ParseException: DOMDocumentFragment::appendXML(): Entity: line 1: parser error : EntityRef: expecting ';' 
....
FAILURES!
Tests: 56, Assertions: 55, Errors: 1.
```