### PR TITLE
Badly formatted youtube URLs cause a parse error

### DIFF
--- a/src/Pass/IframeYouTubeTagTransformPass.php
+++ b/src/Pass/IframeYouTubeTagTransformPass.php
@@ -125,25 +125,25 @@ class IframeYouTubeTagTransformPass extends BasePass
         if (preg_match('&(*UTF8)/embed/([^/?]+)&i', $href, $matches)) {
             if (!empty($matches[1])) {
                 $youtube_code = $matches[1];
-                return $youtube_code;
+                return htmlspecialchars($youtube_code);
             }
         }
 
         if (preg_match('&(*UTF8)youtu\.be/([^/?]+)&i', $href, $matches)) {
             if (!empty($matches[1])) {
                 $youtube_code = $matches[1];
-                return $youtube_code;
+                return htmlspecialchars($youtube_code);
             }
         }
 
         if (preg_match('!(*UTF8)watch\?v=([^&]+)!i', $href, $matches)) {
             if (!empty($matches[1])) {
                 $youtube_code = $matches[1];
-                return $youtube_code;
+                return htmlspecialchars($youtube_code);
             }
         }
 
-        return $youtube_code;
+        return htmlspecialchars($youtube_code);
     }
 
     /**

--- a/tests/test-data/fragment-html/youtube-bad-fragment.html
+++ b/tests/test-data/fragment-html/youtube-bad-fragment.html
@@ -1,0 +1,4 @@
+<iframe data-priority="high" width="560" height="315"
+        src="https://www.youtube.com/embed/MnR9AVs6Q_c&amp;list=PLiGedaJzwg4zAaznvmnz66U6K1-LFpBYk"
+        frameborder="0" allowfullscreen>
+</iframe>

--- a/tests/test-data/fragment-html/youtube-bad-fragment.html.out
+++ b/tests/test-data/fragment-html/youtube-bad-fragment.html.out
@@ -1,0 +1,27 @@
+<amp-youtube data-videoid="MnR9AVs6Q_c&amp;list=PLiGedaJzwg4zAaznvmnz66U6K1-LFpBYk" layout="responsive" data-priority="high" height="315" width="560"></amp-youtube>
+
+
+ORIGINAL HTML
+---------------
+Line 1: <iframe data-priority="high" width="560" height="315"
+Line 2:         src="https://www.youtube.com/embed/MnR9AVs6Q_c&amp;list=PLiGedaJzwg4zAaznvmnz66U6K1-LFpBYk"
+Line 3:         frameborder="0" allowfullscreen>
+Line 4: </iframe>
+Line 5: 
+
+
+Transformations made from HTML tags to AMP custom tags
+-------------------------------------------------------
+
+<iframe data-priority="high" width="560" height="315" src="https://www.youtube.com/embed/MnR9AVs6Q_c&list=PLiGedaJzwg4zAaznvmnz66U6K1-LFpBYk" frameborder allowfullscreen> at line 3
+ ACTION TAKEN: iframe tag was converted to the amp-youtube tag.
+
+
+AMP-HTML Validation Issues and Fixes
+-------------------------------------
+PASS
+
+COMPONENT NAMES WITH JS PATH
+------------------------------
+'amp-youtube', include path 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js'
+


### PR DESCRIPTION
The DOM parser throws away invalid HTML.

When you have http://youtube.com/embed/_FlV6pgwlrk&list=123 then
the `IframeYouTubeTagTransformPass::getYouTubeCode()` will match the
ID as `_FlV6pgwlrk&list=123` but since the ampersand isn't in a
proper HTML format (`&amp;`), then DOM will throw this whole
element away.

I wrote a test to make sure noone breaks this in the future.