### PR TITLE
YouTube Pass change, suppress data-param-autoplay

### DIFF
--- a/src/Pass/IframeYouTubeTagTransformPass.php
+++ b/src/Pass/IframeYouTubeTagTransformPass.php
@@ -159,7 +159,9 @@ class IframeYouTubeTagTransformPass extends BasePass
         //
         // We're doing this in reverse: we see the query parameters and we make them data-param-*
         foreach ($arr as $query_name => $query_value) {
-            $new_dom_el->attr("data-param-$query_name", $query_value);
+            if ($query_name !== 'autoplay') {  // the data-param-autoplay attribute throws errors
+                $new_dom_el->attr("data-param-$query_name", $query_value);
+            }
         }
     }
 }


### PR DESCRIPTION
AMP Validator reports:
"Uncaught Error: Use autoplay attribute instead of data-param-autoplay​​​"

This is a quick n' dirty condition to ensure the 'data-param-autoplay' attribute isn't output.