### PR TITLE
Add amp-sidebar component mapping on context.php

### DIFF
--- a/src/Validate/Context.php
+++ b/src/Validate/Context.php
@@ -96,6 +96,7 @@ class Context
         'amp-vine' => 'https://cdn.ampproject.org/v0/amp-vine-0.1.js',
         'amp-vimeo' => 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js',
         'amp-youtube' => 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js',
+        'amp-sidebar' => 'https://cdn.ampproject.org/v0/amp-sidebar-0.1.js',
         'template' => 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js'
     ];
 


### PR DESCRIPTION
The script wasn't added in the component mapping on Context.php. This commit fix that and if there is a amp-sidebar tag the library will add the required js file.