### PR TITLE
remove img with non-existant source

### DIFF
--- a/tests/test-data/fragment-html/img-test-fragment.html
+++ b/tests/test-data/fragment-html/img-test-fragment.html
@@ -6,7 +6,7 @@
 <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 
-<!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
+<!-- nonexistent image, should refuse to convert to amp-img and remove it -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
 
 <!-- should provide layout and height width and make layout responsive -->

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -6,7 +6,7 @@
 <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="fixed"></amp-img>
 
-<!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
+<!-- nonexistent image, should refuse to convert to amp-img and remove it -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
 
 <!-- should provide layout and height width and make layout responsive -->
@@ -38,7 +38,7 @@ Line  5:
 Line  6: <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 Line  7: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 Line  8: 
-Line  9: <!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
+Line  9: <!-- nonexistent image, should refuse to convert to amp-img and remove it -->
 Line 10: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
 Line 11: 
 Line 12: <!-- should provide layout and height width and make layout responsive -->


### PR DESCRIPTION
We at POPSUGAR have a lot of older posts with tracking pixels, which can't be downloaded anymore. Leaving them in the document, renders document invalid, since they can't be converted into amp-img