### PR TITLE
Removed img tag if transformation fails.

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -75,6 +75,7 @@ class ImgTagTransformPass extends BasePass
             $has_height_and_width = $this->setResponsiveImgHeightAndWidth($el);
             if (!$has_height_and_width) {
                 $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
+                $el->remove();
                 continue;
             }
             if ($this->isPixel($el)) {

--- a/tests/test-data/fragment-html/img-anim-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-anim-test-fragment.html.out
@@ -54,12 +54,7 @@ Transformations made from HTML tags to AMP custom tags
 
 AMP-HTML Validation Issues and Fixes
 -------------------------------------
-FAIL
-
-<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg"> on line 14
-- The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'?
-   [code: MANDATORY_TAG_ANCESTOR_WITH_HINT  category: DISALLOWED_HTML_WITH_AMP_EQUIVALENT see: https://www.ampproject.org/docs/reference/amp-img.html]
-   ACTION TAKEN: img tag was removed due to validation issues.
+PASS
 
 COMPONENT NAMES WITH JS PATH
 ------------------------------

--- a/tests/test-data/fragment-html/img-test-fragment.html
+++ b/tests/test-data/fragment-html/img-test-fragment.html
@@ -6,7 +6,7 @@
 <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 
-<!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
+<!-- nonexistent image, should refuse to convert to amp-img and not include a tag -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
 
 <!-- should provide layout and height width and make layout responsive -->

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -6,8 +6,8 @@
 <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="fixed"></amp-img>
 
-<!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
-<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
+<!-- nonexistent image, should refuse to convert to amp-img and not include a tag -->
+
 
 <!-- should provide layout and height width and make layout responsive -->
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" layout="responsive" width="625" height="480"></amp-img>
@@ -38,7 +38,7 @@ Line  5:
 Line  6: <!-- should transform to amp-img with fixed layout, preserving the width and height -->
 Line  7: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96">
 Line  8: 
-Line  9: <!-- nonexistent image, should refuse to convert to amp-img and keep it as it is -->
+Line  9: <!-- nonexistent image, should refuse to convert to amp-img and not include a tag -->
 Line 10: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">
 Line 11: 
 Line 12: <!-- should provide layout and height width and make layout responsive -->
@@ -83,10 +83,6 @@ Transformations made from HTML tags to AMP custom tags
 AMP-HTML Validation Issues and Fixes
 -------------------------------------
 FAIL
-
-<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg"> on line 10
-- The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'?
-   [code: MANDATORY_TAG_ANCESTOR_WITH_HINT  category: DISALLOWED_HTML_WITH_AMP_EQUIVALENT see: https://www.ampproject.org/docs/reference/amp-img.html]
 
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg"> on line 13
 - The implied layout 'CONTAINER' is not supported by tag 'amp-img'.


### PR DESCRIPTION
Fixes #190 

When img tag transformation fails, it records the failure but leave the blank invalid image tag behind. This PR just removes the element on failure.

Updated img-anim test. This test had the correct delete action but was incorrectly expecting the error.
Update img test for the missing tag. The action taken is still recorded and shown.