### PR TITLE
add getters for status and validation_result

### DIFF
--- a/src/AMP.php
+++ b/src/AMP.php
@@ -127,6 +127,11 @@ class AMP
         return $this->amp_html;
     }
 
+    public function getValidationResult()
+    {
+        return $this->validation_result;
+    }
+
     /**
      * AMP constructor.
      *

--- a/src/Validate/SValidationResult.php
+++ b/src/Validate/SValidationResult.php
@@ -40,6 +40,11 @@ use Lullabot\AMP\Spec\ValidationResultStatus;
  */
 class SValidationResult extends ValidationResult
 {
+
+    public function getStatus(){
+        return $this->status;
+    }
+
     /**
      * Corresponds to maxSpecificity() top level function in validator.js.
      * (see https://github.com/ampproject/amphtml/blob/master/validator/validator.js )


### PR DESCRIPTION

After doing the conversion from HTML to AMP:

`$amp_html = $amp->convertToAmpHtml();`

You can check if the validation is correct or not with a single line:

`$amp->getValidationResult()->getStatus();`

Here is an example:

```
if($amp->getValidationResult()->getStatus() != ValidationResultStatus::PASS){
    print_r("ERROR\n");
} else {
    print_r("OK\n");
}
```