### PR TITLE
https request_scheme is determined incorrectly on case-sensitive systems

### DIFF
--- a/src/AMP.php
+++ b/src/AMP.php
@@ -204,7 +204,7 @@ class AMP
 
         // Get the request scheme http, https etc.
         if (empty($options['request_scheme'])) {
-            if (!empty($_SERVER['https'])) {
+            if (!empty($_SERVER['HTTPS'])) {
                 $this->options['request_scheme'] = 'https://';
             } else {
                 $this->options['request_scheme'] = 'http://';


### PR DESCRIPTION
Key should be uppercased similar to other usage below, otherwise it will never match on *nix systems at least causing incorrect http retrieval.