### PR TITLE
Inputstream deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "~2.3",
+        "masterminds/html5": ">=2.3 <2.5",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
         "marc1706/fast-image-size": "1.*",
-        "masterminds/html5": "~2.3.0",
+        "masterminds/html5": "~2.3",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },

--- a/src/Utility/AMPDOMTreeBuilder.php
+++ b/src/Utility/AMPDOMTreeBuilder.php
@@ -18,7 +18,6 @@
 namespace Lullabot\AMP\Utility;
 
 use Masterminds\HTML5\Parser\DOMTreeBuilder;
-use Masterminds\HTML5\Parser\InputStream;
 use Masterminds\HTML5\Parser\Scanner;
 use Lullabot\AMP\AMP;
 
@@ -46,10 +45,10 @@ class AMPDOMTreeBuilder extends DOMTreeBuilder
 
     /**
      * AMPDOMTreeBuilder constructor.
-     * @param InputStream $inputstream
+     * @param string $inputstream
      * @param array $options
      */
-    public function __construct(InputStream $inputstream, array $options = [])
+    public function __construct($inputstream, array $options = [])
     {
         // We embed a scanner so that $this->startTag() knows the current line number
         $this->scanner = new Scanner($inputstream);

--- a/src/Utility/AMPHTML5.php
+++ b/src/Utility/AMPHTML5.php
@@ -18,7 +18,6 @@
 namespace Lullabot\AMP\Utility;
 
 use Masterminds\HTML5;
-use Masterminds\HTML5\Parser\InputStream;
 
 /**
  * Class AMPHTML5
@@ -39,11 +38,11 @@ class AMPHTML5 extends HTML5
      * Similar to \Masterminds\HTML5::parse() method in superclass but we use our custom (sub-classed) tokenizer and DOM tree
      * builder to achieve desired effect of adding a line number attribute to each tag of the output DOM document.
      *
-     * @param InputStream $inputstream
+     * @param string $inputstream
      * @param array $options
      * @return \DOMDocument
      */
-    public function parse(InputStream $inputstream, array $options = [])
+    public function parse($inputstream, array $options = [])
     {
         // User options override default options in $this->options
         $final_options = array_merge($this->options, $options);


### PR DESCRIPTION
This pull request is based on the following issue
https://github.com/Lullabot/amp-library/issues/247

This issue is caused by and update to mastermind/html5-php  from version 2.3.1 -> 2.4
The code change removes the use of Masterminds\HTML5\Parser\InputStream in favour of strings in order to improve performance.
Furthermore Masterminds\HTML5\Parser\InputStream will be deprecated in version 3.0

For more info You can view the code change in mastermind/html5-php in the link below
https://github.com/Masterminds/html5-php/commit/321ed9626c091f1f4dcef8223d88ee88a400a241

I think this fix is critical as the mastermind/html5-php the composer.json entry in this amp module does not set a fixed version (e.g"masterminds/html5": "^2.2.0", ^2.2.0) so anybody updating composer will pick this up automatically hence breaking their AMP site