### PR TITLE
Update marc1706/fast-image-size

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php" : ">=5.5.0",
         "querypath/QueryPath": ">=3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3",
-        "marc1706/fast-image-size": "1.*",
+        "marc1706/fast-image-size": "^1.1.0",
         "masterminds/html5": "~2.3.0",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1"


### PR DESCRIPTION
This lib is broken with a version below 1.1 of marc1706/fast-image-size