### PR TITLE
Fix for Twitter embeds

### DIFF
--- a/src/Pass/TwitterTransformPass.php
+++ b/src/Pass/TwitterTransformPass.php
@@ -30,7 +30,7 @@ class TwitterTransformPass extends BasePass
 {
     function pass()
     {
-        $all_tweets = $this->q->top()->find('blockquote.twitter-tweet, blockquote.twitter-video');
+        $all_tweets = $this->q->top()->find('blockquote.twitter-tweet:not(blockquote.twitter-tweet > blockquote.twitter-tweet), blockquote.twitter-video');
         /** @var DOMQuery $el */
         foreach ($all_tweets as $el) {
             /** @var \DOMElement $dom_el */

--- a/tests/test-data/fragment-html/twitter-fragment.html
+++ b/tests/test-data/fragment-html/twitter-fragment.html
@@ -10,3 +10,13 @@
     well-done! <a href="https://t.co/xyrO7kQBzH">pic.twitter.com/xyrO7kQBzH</a></p>&mdash; Andy Serkis (@andyserkis) <a
         href="https://twitter.com/andyserkis/statuses/704420904437043200">February 29, 2016</a></blockquote>
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+<!-- twitter embed with double blockquote -->
+<blockquote align="center" class="twitter-tweet" data-dnt="true">
+    <p dir="ltr" lang="en">We're excited to announce that we've been named one of <a href="https://twitter.com/Inc?ref_src=twsrc%5Etfw">@Inc</a>'s Best Workplaces of 2019! 😁 🙌 🎉 👏 See the full list here: <a href="https://t.co/NnKPPmlc0n">https://t.co/NnKPPmlc0n</a> <a href="https://twitter.com/hashtag/IncBestWorkplaces?src=hash&amp;ref_src=twsrc%5Etfw">#IncBestWorkplaces</a> <a href="https://t.co/RlclLbnutX">pic.twitter.com/RlclLbnutX</a></p>
+    — Lullabot (@lullabot) <a href="https://twitter.com/lullabot/status/1129040592930070530?ref_src=twsrc%5Etfw">May 16, 2019</a>
+    <blockquote align="center" class="twitter-tweet" data-dnt="true">
+        <p dir="ltr" lang="en">Do you have that rare combination of technical acumen and the ability to lead teams, make decisions, and get things done? We're looking for a Technical Project Manager to join our team and would love to talk to you! <a href="https://t.co/iAwTYyOKoo">https://t.co/iAwTYyOKoo</a> <a href="https://twitter.com/hashtag/Drupal?src=hash&amp;ref_src=twsrc%5Etfw">#Drupal</a> <a href="https://twitter.com/hashtag/projectmanagement?src=hash&amp;ref_src=twsrc%5Etfw">#projectmanagement</a> <a href="https://t.co/Tt6RExQzBX">pic.twitter.com/Tt6RExQzBX</a></p>
+        — Lullabot (@lullabot) <a href="https://twitter.com/lullabot/status/1130532897142841344?ref_src=twsrc%5Etfw">May 20, 2019</a>
+    </blockquote>
+</blockquote>
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/tests/test-data/fragment-html/twitter-fragment.html.out
+++ b/tests/test-data/fragment-html/twitter-fragment.html.out
@@ -4,6 +4,9 @@
 <!-- normal twitter embed using 'statuses' -->
 <amp-twitter data-cards="hidden" data-lang="en" height="223" width="486" layout="responsive" data-tweetid="704420904437043200"></amp-twitter>
 
+<!-- twitter embed with double blockquote -->
+<amp-twitter data-dnt="true" height="694" width="486" layout="responsive" data-tweetid="1129040592930070530?ref_src=twsrc%5Etfw"></amp-twitter>
+
 
 
 ORIGINAL HTML
@@ -20,7 +23,17 @@ Line  9:         href="https://twitter.com/hashtag/Oscars?src=hash">#Oscars</a>!
 Line 10:     well-done! <a href="https://t.co/xyrO7kQBzH">pic.twitter.com/xyrO7kQBzH</a></p>&mdash; Andy Serkis (@andyserkis) <a
 Line 11:         href="https://twitter.com/andyserkis/statuses/704420904437043200">February 29, 2016</a></blockquote>
 Line 12: <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-Line 13: 
+Line 13: <!-- twitter embed with double blockquote -->
+Line 14: <blockquote align="center" class="twitter-tweet" data-dnt="true">
+Line 15:     <p dir="ltr" lang="en">We're excited to announce that we've been named one of <a href="https://twitter.com/Inc?ref_src=twsrc%5Etfw">@Inc</a>'s Best Workplaces of 2019! 😁 🙌 🎉 👏 See the full list here: <a href="https://t.co/NnKPPmlc0n">https://t.co/NnKPPmlc0n</a> <a href="https://twitter.com/hashtag/IncBestWorkplaces?src=hash&amp;ref_src=twsrc%5Etfw">#IncBestWorkplaces</a> <a href="https://t.co/RlclLbnutX">pic.twitter.com/RlclLbnutX</a></p>
+Line 16:     — Lullabot (@lullabot) <a href="https://twitter.com/lullabot/status/1129040592930070530?ref_src=twsrc%5Etfw">May 16, 2019</a>
+Line 17:     <blockquote align="center" class="twitter-tweet" data-dnt="true">
+Line 18:         <p dir="ltr" lang="en">Do you have that rare combination of technical acumen and the ability to lead teams, make decisions, and get things done? We're looking for a Technical Project Manager to join our team and would love to talk to you! <a href="https://t.co/iAwTYyOKoo">https://t.co/iAwTYyOKoo</a> <a href="https://twitter.com/hashtag/Drupal?src=hash&amp;ref_src=twsrc%5Etfw">#Drupal</a> <a href="https://twitter.com/hashtag/projectmanagement?src=hash&amp;ref_src=twsrc%5Etfw">#projectmanagement</a> <a href="https://t.co/Tt6RExQzBX">pic.twitter.com/Tt6RExQzBX</a></p>
+Line 19:         — Lullabot (@lullabot) <a href="https://twitter.com/lullabot/status/1130532897142841344?ref_src=twsrc%5Etfw">May 20, 2019</a>
+Line 20:     </blockquote>
+Line 21: </blockquote>
+Line 22: <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+Line 23: 
 
 
 Transformations made from HTML tags to AMP custom tags
@@ -30,6 +43,9 @@ Transformations made from HTML tags to AMP custom tags
  ACTION TAKEN: blockquote.twitter-tweet (with twitter script tag) twitter embed code was converted to the amp-twitter tag.
 
 <blockquote data-cards="hidden" class="twitter-tweet" data-lang="en"> at line 8
+ ACTION TAKEN: blockquote.twitter-tweet (with twitter script tag) twitter embed code was converted to the amp-twitter tag.
+
+<blockquote align="center" class="twitter-tweet" data-dnt="true"> at line 14
  ACTION TAKEN: blockquote.twitter-tweet (with twitter script tag) twitter embed code was converted to the amp-twitter tag.
 
 


### PR DESCRIPTION
Fixes #264 

As stated in that issue, there is an issue with embedded tweets that quote other tweets. The issue is that there are nested `<blockquote>` tags, and when the `DOMQuery` loops through the DOM to parse out the tweets to convert to AMP, it runs into an issue. The inner blockquote is one of the elements that are looped through, but before it is processed the outer blockquote containing it is processed first. During processing, the inner blockquote is removed from DOM when the outer blockquote is removed and replaced with its AMP tag. This results in a null error when the loop gets to the previously removed inner blockquote.

In this PR, I have changed the CSS lookup to only grab and loop through the outer blockquotes. This has been running successfully in production for us for over a week, and I've added tests to the test suite, so I feel confident that this fix is working.