### PR TITLE
Infogram implementation

### DIFF
--- a/src/AMP.php
+++ b/src/AMP.php
@@ -60,6 +60,7 @@ class AMP
         'Lullabot\AMP\Pass\IframeDailymotionTagTransformPass',
         'Lullabot\AMP\Pass\IframeYouTubeTagTransformPass',
         'Lullabot\AMP\Pass\IframeTagTransformPass',
+        'Lullabot\AMP\Pass\InfogramTransformPass',
         'Lullabot\AMP\Pass\InstagramTransformPass',
         'Lullabot\AMP\Pass\PinterestTagTransformPass',
         'Lullabot\AMP\Pass\FacebookNonIframeTransformPass',

--- a/src/Pass/InfogramTransformPass.php
+++ b/src/Pass/InfogramTransformPass.php
@@ -1,0 +1,72 @@
+<?php
+namespace Lullabot\AMP\Pass;
+
+use QueryPath\DOMQuery;
+
+use Lullabot\AMP\Utility\ActionTakenLine;
+use Lullabot\AMP\Utility\ActionTakenType;
+
+/**
+ * Class InfogramTransformPass
+ * @package Lullabot\AMP\Pass
+ */
+class InfogramTransformPass extends BasePass
+{
+    function pass()
+    {
+        $all_infogram = $this->q->top()->find('div.infogram-embed');
+        /** @var DOMQuery $el */
+        foreach ($all_infogram as $el) {
+            /** @var \DOMElement $dom_el */
+            $dom_el = $el->get(0);
+            $lineno = $this->getLineNo($dom_el);
+            $context_string = $this->getContextString($dom_el);
+            $script_tag = $this->getScriptTag($el, 'e\.infogram\.com/js\.js&i');
+            
+            $height = isset($this->options['infogram_height'])
+                ? $this->options['infogram_height'] : 937;
+            
+            $width = isset($this->options['infogram_width'])
+                ? $this->options['infogram_width'] : 1161;
+            
+            $src = $el->attr('data-id');
+            
+            if ($src) {
+                $amp_string =<<<"HTML"
+<amp-iframe 
+    height="$height"
+    width="$width"
+    layout="responsive"
+    frameborder="0"
+    sandbox="allow-scripts allow-same-origin allow-popups"
+    resizable="resizable"
+    allowfullscreen="allowfullscreen"
+    src="https://e.infogram.com/$src">
+        <div style="visibility: hidden" overflow="overflow" tabindex="0" role="button" aria-label="Loading..." placeholder="placeholder">Loading...</div>
+    </amp-iframe>
+HTML;
+                
+                $el->after($amp_string);
+                $new_dom_el = $el->get(0);
+                
+                if (!empty($script_tag)) {
+                    $script_tag->remove();
+                    $this->addActionTaken(new ActionTakenLine('a (with associated script tag)', ActionTakenType::INFOGRAM_CONVERTED, $lineno, $context_string));
+                }
+                else {
+                    $this->addActionTaken(new ActionTakenLine('a', ActionTakenType::INFOGRAM_CONVERTED, $lineno, $context_string));
+                }
+                    $this->context->addLineAssociation($new_dom_el, $lineno);
+            }
+            else {
+                $this->addActionTaken(new ActionTakenLine('div.infogram-embed', ActionTakenType::INFOGRAM_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
+            }
+            
+            // Remove the div, its children
+            $el->removeChildren()->remove();
+            
+        }
+        
+        return $this->transformations;
+    }
+}

--- a/src/Utility/ActionTakenType.php
+++ b/src/Utility/ActionTakenType.php
@@ -27,6 +27,8 @@ class ActionTakenType
     const IMG_PIXEL_CONVERTED = 'tag was converted to the amp-pixel tag.';
     const IMG_ANIM_CONVERTED = 'tag was converted to the amp-anim tag.';
     const IMG_COULD_NOT_BE_CONVERTED = 'tag could NOT be converted to the amp-img tag as the image is not accessible.';
+    const INFOGRAM_CONVERTED = 'infogram tag was converted to the amp-iframe tag.';
+    const INFOGRAM_COULD_NOT_BE_CONVERTED = 'infogram tag could NOT be converted to the amp-iframe tag.';
     const INSTAGRAM_CONVERTED = 'instagram embed code was converted to the amp-instagram tag.';
     const PINTEREST_CONVERTED = 'pinterest embed code was converted to the amp-pinterest tag.';
     const VINE_CONVERTED = 'vine embed code was converted to the amp-vine tag.';


### PR DESCRIPTION
Hello!

I'm working on a project that uses [Infogram](https://infogram.com/) for a lot of data reporting within their articles, and needed to be able to auto-convert from their standard embed codes that have been added as Drupal content to [their recommendation](https://developers.infogr.am/amp/) of `amp-iframe` elements.

This pull request essentially mimics what @obeyer [did for Tumblr and Imgur compatibility](https://github.com/Lullabot/amp-library/pull/184/commits/5ca62d346fe60b368e522bff29786a6c8995b726). I've tested this and it's working for me, but if you need any more information, please let me know. Thanks!