### PR TITLE
Update phpunit to v9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor/**
 .idea
 coverage/**
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require" : {
         "php" : ">=5.5",
         "querypath/querypath": ">=3.0.4",
-        "sebastian/diff": "^1.2 || ^2 || ^3",
+        "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require" : {
         "php" : ">=5.5",
         "querypath/querypath": ">=3.0.4",
-        "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
+        "sebastian/diff": "^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1",
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "php" : ">=5.5",
-        "phpunit/phpunit": "4.8.* || ^6",
+        "phpunit/phpunit": "^9",
         "symfony/console": "^2.7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lullabot/amp",
+    "name": "ewilde-imperial/amp",
     "description": "A set of useful classes and utilities to convert html to AMP html (See https://www.ampproject.org/)",
     "authors": [
         {
@@ -9,7 +9,7 @@
     ],
     "license": "Apache-2.0",
     "keywords": ["Drupal", "AMP", "mobile"],
-    "homepage": "https://github.com/Lullabot/amp-library",
+    "homepage": "https://github.com/ewilde-imperial/amp-library",
     "require" : {
         "php" : ">=5.5",
         "querypath/querypath": ">=3.0.4",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,11 @@
-<phpunit>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <file>src/AmpCommand.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <file>src/AmpCommand.php</file>
+    </exclude>
+  </coverage>
 </phpunit>

--- a/tests/AmpTest.php
+++ b/tests/AmpTest.php
@@ -28,7 +28,7 @@ class AmpTest extends TestCase
     protected $amp = null;
     protected $skip_internet = false;
 
-    public function setup()
+    public function setup() : void
     {
         $this->amp = new AMP();
         $this->skip_internet = getenv('AMP_TEST_SKIP_INTERNET');


### PR DESCRIPTION
This updates phpunit to v9 and is required to use this library with any application already running phpunit 9+, since there are unresolvable dependency conflicts with sebastian/diff <4.