### PR TITLE
refacto: remove Guzzle, use HTTPlug instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced Travis with Github Actions for running tests.
 - Allowed sebastian/diff 4.x
 - Fixed tests 
+- Removed Guzzle for HTTPlug, you will need to install a [HTTPlug adapter](https://docs.php-http.org/en/latest/clients.html)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ To use this in your composer based PHP project, refer to [composer docs here](ht
 
 Or you can simply do `$ composer require lullabot/amp:"^1.0.0"` to fetch the library from [here](https://packagist.org/packages/lullabot/amp) and automatically update your `composer.json`
 
+You will also need to install a [HTTPlug's adapter](https://docs.php-http.org/en/latest/clients.html) depending on which HttpClient implementation you want to use, eg: `composer require php-http/guzzle7-adapter`.
+
 ##### Advanced
 Should you wish to follow the bleeding edge you can do `$ composer require lullabot/amp:"dev-master"`. Note that this will create a `.git` folder in `vendor/lullabot/amp`. If you want to avoid that,  do `$ composer require lullabot/amp:"dev-master" --prefer-dist`
 

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,24 @@
         "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",
-        "guzzlehttp/guzzle": "~6.1",
-        "masterminds/html5": "^2.5"
+        "masterminds/html5": "^2.5",
+        "psr/http-message": "^1.0",
+        "psr/http-client-implementation": "^1.0",
+        "php-http/httplug": "^2.0",
+        "php-http/message-factory": "^1.0",
+        "php-http/discovery": "^1.0"
     },
     "autoload": {
         "classmap": ["src/Spec/validator-generated.php"],
         "psr-4": {"Lullabot\\AMP\\": "src"}
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^6.5",
         "phpunit/phpunit": "^5.6.3 || ^6",
-        "symfony/console": "^2.7.0"
+        "symfony/console": "^2.7.0",
+        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/message": "^1.13",
+        "nyholm/psr7": "^1.5"
     },
     "scripts": {
         "test": "phpunit tests"

--- a/src/AmpCommand.php
+++ b/src/AmpCommand.php
@@ -17,6 +17,7 @@
 
 namespace Lullabot\AMP;
 
+use Http\Discovery\HttpClientDiscovery;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Pass/HttpClientAwarePass.php
+++ b/src/Pass/HttpClientAwarePass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lullabot\AMP\Pass;
+
+use Psr\Http\Client\ClientInterface;
+
+interface HttpClientAwarePass
+{
+    public function setHttpClient(ClientInterface $httpClient);
+}

--- a/src/Pass/HttpClientAwareTrait.php
+++ b/src/Pass/HttpClientAwareTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lullabot\AMP\Pass;
+
+use Psr\Http\Client\ClientInterface;
+
+trait HttpClientAwareTrait
+{
+    /** @var ClientInterface */
+    private $httpClient;
+
+    /**
+     * @return ClientInterface
+     */
+    protected function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    public function setHttpClient(ClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+}


### PR DESCRIPTION
When writing those lines, the library is stuck with Guzzle 6, which prevent us to update some of our dependencies due to conflicts. 

A library should not depending of a HttpClient implementation, but should instead use the PSR's interfaces (and HTTPlug), so the user is free to use whatever HttpClient he wants. 