### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "license": "Apache-2.0",
     "keywords": ["Drupal", "AMP", "mobile"],
-    "homepage": "https://github.com/Lullabot/amp-library",
+    "homepage": "https://github.com/deimosindustries/amp-library",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1",
         "masterminds/html5": "^2.5",
-        "arthurkushman/query-path": "^3.1"
+        "gravitypdf/querypath": "^3.2"
     },
     "autoload": {
         "classmap": ["src/Spec/validator-generated.php"],

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,5 @@
 {
-    "name": "deimosindustries/lullabot-amp",
-    "replace": {
-        "lullabot/amp":"2.*"
-    },
+    "name": "lullabot/amp",
     "description": "A set of useful classes and utilities to convert html to AMP html (See https://www.ampproject.org/)",
     "authors": [
         {
@@ -12,9 +9,9 @@
     ],
     "license": "Apache-2.0",
     "keywords": ["Drupal", "AMP", "mobile"],
-    "homepage": "https://github.com/deimosindustries/amp-library",
+    "homepage": "https://github.com/Lullabot/amp-library",
     "require": {
-        "php": ">=7.1",
+        "php": ">=5.6",
         "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
-    "name": "lullabot/amp",
+    "name": "deimosindustries/lullabot-amp",
+    "replace": {
+        "lullabot/amp":"2.*"
+    },
     "description": "A set of useful classes and utilities to convert html to AMP html (See https://www.ampproject.org/)",
     "authors": [
         {
@@ -12,19 +15,19 @@
     "homepage": "https://github.com/Lullabot/amp-library",
     "require": {
         "php": ">=5.6",
-        "querypath/querypath": "^3.0.4",
         "sebastian/diff": "^1.2 || ^2 || ^3 || ^4",
         "marc1706/fast-image-size": "1.*",
         "sabberworm/php-css-parser": "^8.0.0",
         "guzzlehttp/guzzle": "~6.1",
-        "masterminds/html5": "^2.5"
+        "masterminds/html5": "^2.5",
+        "arthurkushman/query-path": "^3.1"
     },
     "autoload": {
         "classmap": ["src/Spec/validator-generated.php"],
         "psr-4": {"Lullabot\\AMP\\": "src"}
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6.3 || ^6",
+        "phpunit/phpunit": "^9.5",
         "symfony/console": "^2.7.0"
     },
     "scripts": {


### PR DESCRIPTION
Adds php 8 compatibility as asked on #302 also solves some waterfall problem on other libraries requiring different forks of the `querypath/querypath` library.