### PR TITLE
fix: php8.2 compatibility

### DIFF
--- a/src/AMP.php
+++ b/src/AMP.php
@@ -353,8 +353,8 @@ class AMP
             . "   If your network is slow, your library processing time will increase and network download time may dominate total time taken for library processing." . PHP_EOL
             . "=END-AMP-STATS-FOOTER=";
 
-        $start_replaced = str_replace("#AMP-START-PLACEHOLDER-${stats_data['start_time']}#", $comment_start, $html);
-        $end_replaced = str_replace("#AMP-END-PLACEHOLDER-${stats_data['start_time']}#", $comment_end, $start_replaced);
+        $start_replaced = str_replace("#AMP-START-PLACEHOLDER-{$stats_data['start_time']}#", $comment_start, $html);
+        $end_replaced = str_replace("#AMP-END-PLACEHOLDER-{$stats_data['start_time']}#", $comment_end, $start_replaced);
 
         return $end_replaced;
     }


### PR DESCRIPTION
From: https://github.com/php/php-src/blob/9a90bd705483004c2ef408ee9e9bb0902beade3f/UPGRADING#L109-L111

>   . The "${var}" and "${expr}" style string interpolations are deprecated and  will be removed in PHP 9. Use "$var"/"{$var}" or "${expr}", respectively.  RFC: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation